### PR TITLE
schema_version supports defination via version module

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/Dad.pm
+++ b/lib/DBIx/Class/DeploymentHandler/Dad.pm
@@ -30,6 +30,7 @@ sub _build_to_version { $_[0]->schema_version }
 has schema_version => (
   is         => 'ro',
   isa        => 'StrSchemaVersion',
+  coerce     => 1,
   lazy_build => 1,
 );
 

--- a/lib/DBIx/Class/DeploymentHandler/Types.pm
+++ b/lib/DBIx/Class/DeploymentHandler/Types.pm
@@ -21,6 +21,12 @@ subtype 'StrSchemaVersion'
     : 'Schema version must be defined'
  };
 
+coerce 'StrSchemaVersion'
+=> from 'Str'
+=> via { $_ }
+=> from 'Object'
+=> via { $_->isa('version') && $_->stringify };
+
 no Moose::Util::TypeConstraints;
 1;
 

--- a/lib/DBIx/Class/DeploymentHandler/VersionHandler/DatabaseToSchemaVersions.pm
+++ b/lib/DBIx/Class/DeploymentHandler/VersionHandler/DatabaseToSchemaVersions.pm
@@ -1,14 +1,16 @@
 package DBIx::Class::DeploymentHandler::VersionHandler::DatabaseToSchemaVersions;
 
 use Moose;
+use DBIx::Class::DeploymentHandler::Types;
 
 # ABSTRACT: Go straight from Database to Schema version
 
 with 'DBIx::Class::DeploymentHandler::HandlesVersioning';
 
 has schema_version => (
-  isa      => 'Str',
+  isa      => 'StrSchemaVersion',
   is       => 'ro',
+  coerce   => 1,
   required => 1,
 );
 

--- a/t/01-dbix-class-ceploymentHandler-dad.t
+++ b/t/01-dbix-class-ceploymentHandler-dad.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use version;
+use Test::More;
+use_ok("DBIx::Class::DeploymentHandler::Dad");
+
+subtest "schema version object", sub {
+    my $v = "0.1";
+    {
+
+        package Foo;
+        $Foo::VERSION = version->parse($v);
+        sub schema_version {$Foo::VERSION}
+        1;
+    }
+
+    my $c = new_ok("DBIx::Class::DeploymentHandler::Dad", [schema => "Foo"]);
+    is($c->schema_version, $v);
+};
+
+subtest "schema version string", sub {
+    my $v = "0.2";
+    {
+
+        package Bar;
+        $Bar::VERSION = $v;
+        sub schema_version {$Bar::VERSION}
+        1;
+    }
+
+    my $c = new_ok("DBIx::Class::DeploymentHandler::Dad", [schema => "Bar"]);
+    is($c->schema_version, $v);
+};
+
+done_testing();

--- a/t/01-deploymenthandler-versionhandler-databasetoschemaversions.t
+++ b/t/01-deploymenthandler-versionhandler-databasetoschemaversions.t
@@ -1,0 +1,38 @@
+#!perl
+
+use strict;
+use warnings;
+use version;
+use Test::More;
+
+my $m
+    = "DBIx::Class::DeploymentHandler::VersionHandler::DatabaseToSchemaVersions";
+use_ok($m);
+
+subtest "$m version object", sub {
+    my $v = qv("1.0");
+    my $c = new_ok(
+        $m,
+        [
+            to_version       => "$v",
+            database_version => "$v",
+            schema_version   => $v,
+        ]
+    );
+    is($c->schema_version, $v);
+};
+
+subtest "$m version string", sub {
+    my $v = "0.1";
+    my $c = new_ok(
+        $m,
+        [
+            to_version       => $v,
+            database_version => $v,
+            schema_version   => $v,
+        ]
+    );
+    is($c->schema_version, $v);
+};
+
+done_testing();


### PR DESCRIPTION
I trapped into exception:
```text
Attribute (schema_version) does not pass the type constraint because: Schema version (currently 'v0.11') must be a string at reader DBIx::Class::DeploymentHandler::Dad::schema_version (defined at ../DBIx-Class-DeploymentHandler/lib/DBIx/Class/DeploymentHandler/Dad.pm line 30
```
because I used [version modul](https://metacpan.org/pod/distribution/version/lib/version.pm) for schema version definition. Therefore I slightly modified your implementation and I hope it could be useful for the other perl geeks.