### PR TITLE
Fix typo in ::HandlesDeploy documentation

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/HandlesDeploy.pm
+++ b/lib/DBIx/Class/DeploymentHandler/HandlesDeploy.pm
@@ -81,8 +81,8 @@ The version set uniquely identifies the migration.
 =method prepare_downgrade
 
  $dh->prepare_downgrade({
-   from_version => 1,
-   to_version   => 2,
+   from_version => 2,
+   to_version   => 1,
    version_set  => [1, 2]
  });
 


### PR DESCRIPTION
This documentation for `prepare_downgrade` looked surprising, and seems to have been copied from the doc for `prepare_upgrade`. Is this change correct?