### PR TITLE
Fix incorrect argument type to _run_sql_and_perl

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -571,7 +571,7 @@ sub install_resultsource {
       $version,
     )
   ];
-  $self->_run_sql_and_perl($files, '', [$version]);
+  $self->_run_sql_and_perl($files, [], [$version]);
 }
 
 sub prepare_resultsource_install {


### PR DESCRIPTION
Found this while testing other stuff - `_run_sql_and_perl` assumes an arrayref here, but we provide a string.

I've not currently investigated how I can amend the tests to tickle this because I've got my head full of amended tests already, so if no one looks at adding tests before I pop my stack I'll come back to it.