### PR TITLE
Separate install and deploy

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+ - Deployment method is now consistent with prepare method:
+   * "deploy" deploys your schema
+   * "install_version_storage" installs the version storage, but not your schema
+   * "install" runs install_version_storage, then deploy
 
 0.002222  2018-01-06 10:25:42-08:00 America/Los_Angeles
  - Stop defaulting to include DROP TABLE, introduced by fix in prior release

--- a/lib/DBIx/Class/DeploymentHandler/Dad.pm
+++ b/lib/DBIx/Class/DeploymentHandler/Dad.pm
@@ -39,8 +39,10 @@ sub install {
 
   my $version = (shift @_ || {})->{version} || $self->to_version;
   log_info { "installing version $version" };
-  croak 'Install not possible as versions table already exists in database'
+  croak 'Install not possible as versions table already exists in database (try deploy)'
     if $self->version_storage_is_installed;
+
+  $self->install_version_storage({ version => $version });
 
   $self->txn_do(sub {
      my $ddl = $self->deploy({ version=> $version });

--- a/lib/DBIx/Class/DeploymentHandler/Dad.pm
+++ b/lib/DBIx/Class/DeploymentHandler/Dad.pm
@@ -45,12 +45,7 @@ sub install {
   $self->install_version_storage({ version => $version });
 
   $self->txn_do(sub {
-     my $ddl = $self->deploy({ version=> $version });
-
-     $self->add_database_version({
-       version     => $version,
-       ddl         => $ddl,
-     });
+     $self->deploy({ version=> $version });
   });
 }
 

--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -114,6 +114,7 @@ sub __ddl_consume_with_prefix {
      opendir my($dh), $dir;
      %files =
        map { $_ => "$dir/$_" }
+       grep { ! /__VERSION/ }
        grep { /\.(?:sql|pl|sql-\w+)$/ && -f "$dir/$_" }
        readdir $dh;
      closedir $dh;

--- a/lib/DBIx/Class/DeploymentHandler/Deprecated.pm
+++ b/lib/DBIx/Class/DeploymentHandler/Deprecated.pm
@@ -54,6 +54,10 @@ sub BUILD {
   $self->version_storage;
 }
 
+# This is called from the new version of Dad, but in this old version, we don't
+# need it to do anything - merely exist
+sub install_version_storage{}
+
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/lib/DBIx/Class/DeploymentHandler/WithReasonableDefaults.pm
+++ b/lib/DBIx/Class/DeploymentHandler/WithReasonableDefaults.pm
@@ -41,6 +41,24 @@ around install_resultsource => sub {
   $self->$orig($source, $version);
 };
 
+around deploy => sub {
+  my $orig = shift;
+  my $self = shift;
+
+  my $sql = $self->$orig(@_);
+
+  my $args = $_[0] || {};
+  my $version = $args->{version} || $self->deploy_method->schema_version;
+
+  $self->add_database_version({
+    version     => $version,
+    ddl         => $sql,
+  });
+
+  return $sql;
+};
+
+
 1;
 
 __END__


### PR DESCRIPTION
Further to my discussion https://github.com/frioux/DBIx-Class-DeploymentHandler/issues/50, I've fixed it up so that the change actually works. This was simply done by calling `install_version_storage` inside `install` and then ignoring `__VERSION` inside everything else.

Please note this also includes the commit found here https://github.com/frioux/DBIx-Class-DeploymentHandler/pull/53 because I discovered that problem as a result of this amendment, so I had to have it in the branch.