### PR TITLE
generate short package names for scripts

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -8,6 +8,7 @@ use autodie;
 use Carp qw( carp croak );
 use DBIx::Class::DeploymentHandler::LogImporter qw(:log :dlog);
 use Context::Preserve;
+use Digest::MD5;
 
 use Try::Tiny;
 
@@ -281,15 +282,35 @@ sub _run_sql {
   };
 }
 
+my ( %f2p, %p2f );
+sub _generate_script_package_name {
+    my $file = shift;
+
+    my $pkgbase = 'DBICDH::Sandbox::';
+    my $maxlen = 200;    # actual limit is "about 250" according to perldiag
+
+    return $pkgbase . $f2p{"$file"} if $f2p{"$file"};
+
+    my $package = Digest::MD5::md5_hex("$file");
+    $package++ while exists $p2f{$package};    # increment until unique
+
+    die "unable to generate a unique short name for '$file'"
+      if length($pkgbase) + length($package) > $maxlen;
+
+    $f2p{"$file"} = $package;
+    $p2f{$package} = "$file";
+
+    return $pkgbase . $package;
+}
+
 sub _load_sandbox {
   my $_file = shift;
   $_file = "$_file";
 
-  my $_package = $_file;
-  $_package =~ s/([^A-Za-z0-9_])/sprintf("_%2x", ord($1))/eg;
+  my $_package = _generate_script_package_name($_file);
 
   my $fn = eval sprintf <<'END_EVAL', $_package;
-package DBICDH::Sandbox::%s;
+package %s;
 {
   our $app;
   $app ||= require $_file;


### PR DESCRIPTION
_load_sandbox was dynamically building packages and naming them after
the full path of the script file.  Perl limits package names to "about
250" characters according to perldiag, which could easily be exceeded by
a path.

Fixes #55 

I'm not sure what DBICDH's current minimum Perl version is, but state requires at least 5.10.