### PR TITLE
Use producer_args for SQL::Translator::Diff->new

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -494,7 +494,7 @@ sub _sqldiff_from_yaml {
   return [SQL::Translator::Diff::schema_diff(
      $source_schema, $db,
      $dest_schema,   $db,
-     $sqltargs
+     { producer_args => $sqltargs }
   )];
 }
 


### PR DESCRIPTION
Since these args are intended to be passed to the SQL::Translator inside
of SQL::Translotor::Diff, they need to be passed as `producer_args`
instead of raw hash keys.

I discovered this while rjbs and I were trying to track down a bug with column names that weren't being quoted properly in the Postgres producer (but only in the generated SQL in `upgrade/`, not in `deploy/`). That problem turned out to be a bug in SQL::Translator::Producer::PostgreSQL, but nonetheless uncovered this bug in DBIC::DH!