### PR TITLE
List "Module::Runtime" as dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'namespace::autoclean' => 0;
 requires 'Log::Contextual' => 0.005005;
 requires 'Path::Class' => 0.26;
 requires 'DBIx::Class' => 0.08121;
+requires 'Module::Runtime' => 0.001;
 requires 'Moose' => 1.0;
 requires 'Moo' => 1.003000;
 requires 'MooseX::Role::Parameterized' => 0.18;


### PR DESCRIPTION
Hello @frioux,

although [CPANTS](https://cpants.cpanauthors.org/dist/DBIx-Class-DeploymentHandler) evaluates this module's Core Kwalitee with 100.00, "Module::Runtime" is missing as dependency ([prereq_matches_use](https://cpants.cpanauthors.org/kwalitee/prereq_matches_use)).

So I specified it in cpanfile with version 0.001, because it is the version where "use_module" was released in "Module::Runtime".

(Oh yes, and this is part of the CPAN PRC 2018 ;-) )