### PR TITLE
Sql splitstatement

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+ - Add txn_wrap attribute to DBIC::DeploymentHandler
 
 0.002232  2019-06-06 21:49:17-04:00 America/New_York
  - Add missing dependency on YAML.pm

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
  - Add txn_wrap attribute to DBIC::DeploymentHandler
  - Bugfix: Do not remove "false" transactions in deploy()
+ - use SQL::SplitStatement to split SQL statements in DDLs
 
 0.002232  2019-06-06 21:49:17-04:00 America/New_York
  - Add missing dependency on YAML.pm

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for {{$dist->name}}
  - Add txn_wrap attribute to DBIC::DeploymentHandler
  - Bugfix: Do not remove "false" transactions in deploy()
  - use SQL::SplitStatement to split SQL statements in DDLs
+ - Add txn_prep attribute to keep backwards-compatibility
 
 0.002232  2019-06-06 21:49:17-04:00 America/New_York
  - Add missing dependency on YAML.pm

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
  - Add txn_wrap attribute to DBIC::DeploymentHandler
+ - Bugfix: Do not remove "false" transactions in deploy()
 
 0.002232  2019-06-06 21:49:17-04:00 America/New_York
  - Add missing dependency on YAML.pm

--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,7 @@ requires 'Context::Preserve' => 0.01;
 requires 'Sub::Exporter::Progressive' => 0;
 requires 'Text::Brew' => 0.02;
 requires 'YAML' => 0.66;
+requires 'SQL::SplitStatement' => '1.00020';
 
 on test => sub {
    requires 'Test::More' => 0.88;

--- a/lib/DBIx/Class/DeploymentHandler.pm
+++ b/lib/DBIx/Class/DeploymentHandler.pm
@@ -16,7 +16,7 @@ with 'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
     delegate_name        => 'deploy_method',
     attributes_to_assume => [qw(schema schema_version version_source)],
     attributes_to_copy   => [qw(
-      ignore_ddl databases script_directory sql_translator_args force_overwrite
+      ignore_ddl databases script_directory sql_translator_args force_overwrite txn_wrap
     )],
   },
   'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
@@ -146,15 +146,87 @@ And much, much more!
 That's really just a taste of some of the differences.  Check out each role for
 all the details.
 
+=head1 ATTRIBUTES
+
+This is just a "stub" section to make clear
+that the bulk of implementation is documented somewhere else.
+
+=head2 Attributes passed to L<DBIx::Class::DeploymentHandler::HandlesDeploy>
+
+=over
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/ignore_ddl>
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/databases>
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/script_directory>
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/sql_translator_args>
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/force_overwrite>
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/txn_wrap>
+
+=back
+
+=head2 Attributes passed to L<DBIx::Class::DeploymentHandler::HandlesVersioning>
+
+=over
+
+=item *
+
+initial_version
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::Dad/schema_version>
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::Dad/to_version>
+
+=back
+
+=head2 Attributes passed to L<DBIx::Class::DeploymentHandler::HandlesVersionStorage>
+
+=over
+
+=item *
+
+version_source
+
+=item *
+
+version_class
+
+=back
+
+=head2 Attributes Inherited from Parent Class
+
+See L<DBIx::Class::DeploymentHandler::Dad/ATTRIBUTES> and
+L<DBIx::Class::DeploymentHandler::Dad/"ORTHODOX METHODS"> for the remaining
+available attributes to pass to C<new>.
+
 =head1 METHODS
 
 This is just a "stub" section to make clear
 that the bulk of implementation is documented in
 L<DBIx::Class::DeploymentHandler::Dad>. Since that is implemented using
 L<Moose> class, see L<DBIx::Class::DeploymentHandler::Dad/ATTRIBUTES>
-and L<DBIx::Class::DeploymentHandler::Dad/"ORTHODOX METHODS"> for
-available attributes to pass to C<new>, and methods callable on the
-resulting object.
+and L<DBIx::Class::DeploymentHandler::Dad/"ORTHODOX METHODS"> for methods
+callable on the resulting object.
 
 =head2 new
 
@@ -164,10 +236,6 @@ resulting object.
     databases           => 'SQLite',
     sql_translator_args => { add_drop_table => 0 },
   });
-
-See L<DBIx::Class::DeploymentHandler::Dad/ATTRIBUTES> and
-L<DBIx::Class::DeploymentHandler::Dad/"ORTHODOX METHODS"> for available
-attributes to pass to C<new>.
 
 =head1 WHERE IS ALL THE DOC?!
 

--- a/lib/DBIx/Class/DeploymentHandler.pm
+++ b/lib/DBIx/Class/DeploymentHandler.pm
@@ -16,7 +16,7 @@ with 'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
     delegate_name        => 'deploy_method',
     attributes_to_assume => [qw(schema schema_version version_source)],
     attributes_to_copy   => [qw(
-      ignore_ddl databases script_directory sql_translator_args force_overwrite txn_wrap
+      ignore_ddl databases script_directory sql_translator_args force_overwrite txn_prep txn_wrap
     )],
   },
   'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
@@ -174,6 +174,10 @@ L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/sql_translator_a
 =item *
 
 L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/force_overwrite>
+
+=item *
+
+L<DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator/txn_prep>
 
 =item *
 

--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -1107,8 +1107,8 @@ The (current) default behavior is to create DDLs wrapped in transactions and
 to remove anything that looks like a transaction from the generated DDLs
 later I<when running the deployment>.
 
-Since this default behaviour is error prone it is strictly recommended to
-enable the C<txn_prep> attribute and remove all transaction statements from
+Since this default behavior is error prone it is strictly recommended to set
+the C<txn_prep> attribute to false and remove all transaction statements from
 previously generated DDLs.
 
 =attr txn_wrap

--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -344,9 +344,9 @@ sub _split_sql_chunk {
   my $storage_class = ref $self->storage;
   $storage_class =~ s/.*://;
   my $feature = $STORAGE2FEATURE{$storage_class} || $STORAGE2FEATURE{MySQL};
+  my $txn; $txn = $feature->{txn} if $self->txn_wrap;
   for ( @sql ) {
     # strip transactions
-    my $txn = $feature->{txn};
     s/^\s*($txn|COMMIT\b).*//mgi if $txn;
     # remove comments
     my $comment = $feature->{comment};

--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -12,6 +12,7 @@ use Digest::MD5;
 
 use Try::Tiny;
 
+use SQL::SplitStatement '1.00020';
 use SQL::Translator;
 require SQL::Translator::Diff;
 
@@ -94,6 +95,14 @@ sub _build_schema_version {
   my $self = shift;
   $self->schema->schema_version
 }
+
+has sql_splitter => (
+    is => 'ro',
+    lazy => 1,
+    builder => '_build_sql_splitter',
+);
+
+sub _build_sql_splitter { SQL::SplitStatement->new }
 
 sub __ddl_consume_with_prefix {
   my ($self, $type, $versions, $prefix) = @_;
@@ -252,119 +261,20 @@ sub _run_sql_array {
   return join "\n", @$sql
 }
 
-my %STORAGE2FEATURE = (
-  SQLServer => {
-    txn => qr/begin\s+transaction\b/i,
-    comment => {
-      DD => 1, # --
-      HASH => 1,
-      SSTAR => 1, # /* */
-      DS => 1, # //
-      PERCENT => 1,
-    },
-  },
-  Sybase => {
-    txn => qr/begin\s+transaction\b/i,
-    comment => {
-      DD => 1,
-      SSTAR => 1,
-      DS => 1,
-      PERCENT => 1,
-    },
-  },
-  SQLite => {
-    txn => qr/begin\b/i,
-    comment => {
-      DD => 1,
-      HASH => 1,
-    },
-  },
-  MySQL => {
-    txn => qr/(begin\b|start\s+transaction\b)/i,
-    comment => {
-      DD => 1,
-      HASH => 1,
-      SS => 1,
-    },
-  },
-  Oracle => {
-    comment => {
-      DD => 1,
-      HASH => 1,
-      SS => 1,
-    },
-  },
-  Pg => {
-    txn => qr/begin\b/i,
-    chunk => sub {
-      my ($c) = @_;
-      my @ret;
-      my $accumulator = '';
-      while (length $c) {
-        if ($c =~ s/\A([^\$]*?);//s) {
-          $accumulator .= $1;
-          push @ret, $accumulator;
-          $accumulator = '';
-        } elsif (
-          $c =~ s/\A(
-            .*?
-            ( \$ [^\$]* \$ )
-          )//xs
-        ) {
-          # got a $...$ .. $...$ chunk
-          $accumulator .= $1;
-          my $anchor = $2;
-          $c =~ s/\A(
-            .*?
-            \Q$anchor\E
-          )//xs;
-          $accumulator .= $1;
-        } elsif ($c =~ s/\A\s*\z//s) {
-          push @ret, $accumulator;
-          $accumulator = '';
-        } else {
-          push @ret, $accumulator.$c;
-          $accumulator = '';
-          last;
-        }
-      }
-      @ret;
-    },
-    comment => {
-      DD => 1,
-      HASH => 1,
-    },
-  },
-);
-
-# split a chunk o' SQL into statements
 sub _split_sql_chunk {
   my $self = shift;
-  my @sql = map { $_.'' } @_; # copy
-  my $storage_class = ref $self->storage;
-  $storage_class =~ s/.*://;
-  my $feature = $STORAGE2FEATURE{$storage_class} || $STORAGE2FEATURE{MySQL};
+
+  # MySQL's DELIMITER is not understood by the server but handled on the client.
+  # SQL::SplitStatement treats the statements between the DELIMITERs correctly
+  # as ONE statement - but it does not remove the DELIMITER lines.
+  # https://rt.cpan.org/Public/Bug/Display.html?id=130473
+  my @sql = grep { /^(?!DELIMITER\s+)/i } map { $self->sql_splitter->split($_) } @_;
+
   for ( @sql ) {
-    # remove comments
-    my $comment = $feature->{comment};
-    s{--.*}{}gm if $comment->{DD};
-    s{/\* .*? \*/}{}xs if $comment->{SS};
-    s{//.*}{}gm if $comment->{DS};
-    s{#.*}{}gm if $comment->{HASH};
-    s{%.*}{}gm if $comment->{PERCENT};
+    s/\s*\n+\s*/ /g;    # put on single line
   }
-  my $chunk = $feature->{chunk} || sub { split /;\n/, $_[0] };
-  @sql = map $chunk->($_), @sql;
-  for ( @sql ) {
-    # trim whitespace
-    s/^\s+//gm;
-    s/\s+$//gm;
-    # remove blank lines
-    s/^\n//gm;
-    # put on single line
-    s/\n/ /g;
-  }
-  return grep $_, @sql;
+
+  return @sql;
 }
 
 sub _run_sql {

--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -271,7 +271,7 @@ my %TXN = (
   SQLServer => qr/(BEGIN\s+TRANSACTION\b|COMMIT\b)/i,
   Sybase    => qr/(BEGIN\s+TRANSACTION\b|COMMIT\b)/i,
   SQLite    => qr/(BEGIN\b|COMMIT\b)/i,
-  MySQL     => qr/(BEGIN\b|START\s+TRANSACTION\b|COMMIT\b)/i,
+  mysql     => qr/(BEGIN\b|START\s+TRANSACTION\b|COMMIT\b)/i,
   Oracle    => qr/COMMIT\b/i,
   Pg        => qr/(BEGIN\b|COMMIT\b)/i,
 );
@@ -279,7 +279,7 @@ my %TXN = (
 sub _split_sql_chunk {
   my $self = shift;
   my ($storage_class) = ref($self->storage) =~ /.*:(\w+)$/;
-  my $txn = $TXN{$storage_class} || $TXN{MySQL};
+  my $txn = $TXN{$storage_class} || $TXN{mysql};
 
   # MySQL's DELIMITER is not understood by the server but handled on the client.
   # SQL::SplitStatement treats the statements between the DELIMITERs correctly
@@ -289,7 +289,7 @@ sub _split_sql_chunk {
   # is true then anything that looks like a transaction is removed here.
   my @sql =
     grep {
-      ($storage_class ne 'MySQL' || /^(?!DELIMITER\s+)/i) &&
+      ($storage_class ne 'mysql' || /^(?!DELIMITER\s+)/i) &&
       (!$self->txn_prep || /^(?!$txn)/gim)
     }
     map {

--- a/t/02-instantiation-no-ddl-no-wrap.t
+++ b/t/02-instantiation-no-ddl-no-wrap.t
@@ -1,0 +1,170 @@
+#!perl
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use DBICDHTest;
+use DBIx::Class::DeploymentHandler;
+use aliased 'DBIx::Class::DeploymentHandler', 'DH';
+
+use Test::More;
+use File::Temp 'tempdir';
+use Test::Fatal qw(lives_ok dies_ok);
+use DBI;
+
+my $dbh = DBICDHTest::dbh();
+my @connection = (sub { $dbh }, { ignore_version => 1 });
+my $sql_dir = tempdir( CLEANUP => 1 );
+
+VERSION1: {
+  use_ok 'DBICVersion_v1';
+  my $s = DBICVersion::Schema->connect(@connection);
+  $DBICVersion::Schema::VERSION = 1;
+  ok($s, 'DBICVersion::Schema 1 instantiates correctly');
+  my $handler = DH->new({
+    ignore_ddl => 1,
+    script_directory => $sql_dir,
+    schema => $s,
+    databases => [],
+    sql_translator_args => { add_drop_table => 0 },
+    txn_wrap => 0,
+  });
+
+  ok($handler, 'DBIx::Class::DeploymentHandler w/1 instantiates correctly');
+
+  my $version = $s->schema_version;
+  $handler->prepare_install;
+
+  dies_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+    })
+  } 'schema not deployed';
+  $handler->install;
+  dies_ok {
+    $handler->install;
+  } 'cannot install twice';
+  lives_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+    })
+  } 'schema is deployed';
+}
+
+VERSION2: {
+  use_ok 'DBICVersion_v2';
+  my $s = DBICVersion::Schema->connect(@connection);
+  $DBICVersion::Schema::VERSION = 2;
+  ok($s, 'DBICVersion::Schema 2 instantiates correctly');
+  my $handler = DH->new({
+    ignore_ddl => 1,
+    script_directory => $sql_dir,
+    schema => $s,
+    databases => [],
+    txn_wrap => 0,
+  });
+
+  ok($handler, 'DBIx::Class::DeploymentHandler w/2 instantiates correctly');
+
+  my $version = $s->schema_version();
+  $handler->prepare_install;
+  dies_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+    })
+  } 'schema not deployed';
+  dies_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+    })
+  } 'schema not uppgrayyed';
+  $handler->upgrade;
+  lives_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+    })
+  } 'schema is deployed';
+}
+
+VERSION3: {
+  use_ok 'DBICVersion_v3';
+  my $s = DBICVersion::Schema->connect(@connection);
+  $DBICVersion::Schema::VERSION = 3;
+  ok($s, 'DBICVersion::Schema 3 instantiates correctly');
+  my $handler = DH->new({
+    ignore_ddl => 1,
+    script_directory => $sql_dir,
+    schema => $s,
+    databases => [],
+    txn_wrap => 0,
+  });
+
+  ok($handler, 'DBIx::Class::DeploymentHandler w/3 instantiates correctly');
+
+  my $version = $s->schema_version();
+  $handler->prepare_install;
+  dies_ok {
+    $s->resultset('Foo')->create({
+        bar => 'frew',
+        baz => 'frew',
+        biff => 'frew',
+      })
+  } 'schema not deployed';
+  $handler->upgrade;
+  lives_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+      biff => 'frew',
+    })
+  } 'schema is deployed';
+}
+
+DOWN2: {
+  use_ok 'DBICVersion_v4';
+  my $s = DBICVersion::Schema->connect(@connection);
+  $DBICVersion::Schema::VERSION = 2;
+  ok($s, 'DBICVersion::Schema 2 instantiates correctly');
+  my $handler = DH->new({
+    ignore_ddl => 1,
+    script_directory => $sql_dir,
+    schema => $s,
+    databases => [],
+    txn_wrap => 0,
+  });
+
+  ok($handler, 'DBIx::Class::DeploymentHandler w/2 instantiates correctly');
+
+  my $version = $s->schema_version();
+  lives_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+      biff => 'frew',
+    })
+  } 'schema at version 3';
+  $handler->downgrade;
+  dies_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+      biff => 'frew',
+    })
+  } 'schema not at version 3';
+  lives_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+    })
+  } 'schema is at version 2';
+
+  is $handler->version_storage->database_version => 2,
+    'database version is down to 2';
+
+}
+
+done_testing;

--- a/t/02-instantiation-no-ddl.t
+++ b/t/02-instantiation-no-ddl.t
@@ -32,7 +32,6 @@ VERSION1: {
 
   ok($handler, 'DBIx::Class::DeploymentHandler w/1 instantiates correctly');
 
-  my $version = $s->schema_version;
   $handler->prepare_install;
 
   dies_ok {
@@ -65,7 +64,6 @@ VERSION2: {
 
   ok($handler, 'DBIx::Class::DeploymentHandler w/2 instantiates correctly');
 
-  my $version = $s->schema_version();
   $handler->prepare_install;
   dies_ok {
     $s->resultset('Foo')->create({
@@ -102,7 +100,6 @@ VERSION3: {
 
   ok($handler, 'DBIx::Class::DeploymentHandler w/3 instantiates correctly');
 
-  my $version = $s->schema_version();
   $handler->prepare_install;
   dies_ok {
     $s->resultset('Foo')->create({
@@ -135,7 +132,6 @@ DOWN2: {
 
   ok($handler, 'DBIx::Class::DeploymentHandler w/2 instantiates correctly');
 
-  my $version = $s->schema_version();
   lives_ok {
     $s->resultset('Foo')->create({
       bar => 'frew',
@@ -160,6 +156,44 @@ DOWN2: {
 
   is $handler->version_storage->database_version => 2,
     'database version is down to 2';
+}
+
+DOWN1: {
+  use_ok 'DBICVersion_v1';
+  my $s = DBICVersion::Schema->connect(@connection);
+  $DBICVersion::Schema::VERSION = 1;
+  ok($s, 'DBICVersion::Schema 1 instantiates correctly');
+  my $handler = DH->new({
+    ignore_ddl => 1,
+    script_directory => $sql_dir,
+    schema => $s,
+    databases => [],
+    txn_prep => 0,
+  });
+
+  ok($handler, 'DBIx::Class::DeploymentHandler w/1 instantiates correctly');
+
+  lives_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+    })
+  } 'schema at version 2';
+  $handler->downgrade;
+  dies_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+      baz => 'frew',
+    })
+  } 'schema not at version 2';
+  lives_ok {
+    $s->resultset('Foo')->create({
+      bar => 'frew',
+    })
+  } 'schema is at version 1';
+
+  is $handler->version_storage->database_version => 1,
+    'database version is down to 1';
 
 }
 

--- a/t/10-split-sql-chunk.t
+++ b/t/10-split-sql-chunk.t
@@ -1,14 +1,16 @@
 use strict;
 use warnings;
+use 5.010;
 
 use Test::More;
 
 use DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator;
 
 sub make_dm {
-  my ($storage_class) = @_;
+  my $storage_class = shift;
   bless {
     storage => bless({}, 'DBIx::Class::Storage::DBI::'.$storage_class),
+    @_,
   }, 'DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator';
 }
 
@@ -22,6 +24,65 @@ END;
 END
 
 is_deeply [ $dm->_split_sql_chunk( 'foo', ' ', 'bar' ) ], [qw(foo bar)];
+
+$dm = make_dm('MySQL', txn_prep => 1);  # default, bw-comp.
+
+is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],
+BEGIN;
+-- stuff
+DELIMITER $$
+insert into door (color) VALUES ('#f00')$$
+SELECT * FROM YADAH$$
+DELIMITER ;
+Commit;
+END
+  [
+    q(insert into door (color) VALUES ('#f00')),
+    'SELECT * FROM YADAH',
+  ];
+
+$dm = make_dm('MySQL', txn_prep => 0);
+
+is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],
+BEGIN;
+-- stuff
+DELIMITER $$
+insert into door (color) VALUES ('#000')$$
+SELECT * FROM YADAH$$
+DELIMITER ;
+Commit;
+END
+  [
+    'BEGIN',
+    q(insert into door (color) VALUES ('#000')),
+    'SELECT * FROM YADAH',
+    'Commit',
+  ];
+
+$dm = make_dm('MySQL', txn_prep => 0);
+
+is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],
+insert into door (color) VALUES ('#000');
+
+CREATE TRIGGER upd_check BEFORE UPDATE ON account
+     FOR EACH ROW
+     BEGIN
+         IF NEW.amount < 0 THEN
+             SET NEW.amount = 0;
+         ELSEIF NEW.amount > 100 THEN
+             SET NEW.amount = 100;
+         END IF;
+     END;
+
+SELECT * FROM YADAH;
+
+END
+  [
+    q(insert into door (color) VALUES ('#000')),
+    'CREATE TRIGGER upd_check BEFORE UPDATE ON account FOR EACH ROW BEGIN IF NEW.amount < 0 THEN SET NEW.amount = 0; ELSEIF NEW.amount > 100 THEN SET NEW.amount = 100; END IF; END',
+    'SELECT * FROM YADAH',
+  ];
+
 
 $dm = make_dm('Pg');
 is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],

--- a/t/10-split-sql-chunk.t
+++ b/t/10-split-sql-chunk.t
@@ -14,7 +14,7 @@ sub make_dm {
 
 my $dm = make_dm('MySQL');
 
-is_deeply [ $dm->_split_sql_chunk( <<'END' ) ], [ 'SELECT * FROM YADAH END' ];
+is_deeply [ $dm->_split_sql_chunk( <<'END' ) ], [ 'BEGIN SELECT * FROM YADAH END' ];
 BEGIN
     -- stuff
     SELECT * FROM YADAH
@@ -38,7 +38,7 @@ CREATE FUNCTION add_rating() RETURNS trigger AS $add_rating$
  END;
 $add_rating$ LANGUAGE plpgsql;
 END
-  [ q{CREATE FUNCTION add_rating() RETURNS trigger AS $add_rating$ IF NEW."type" = 'like' THEN UPDATE "list_materials" SET "likes" = (SELECT COUNT(*) FROM "list_material_ratings" WHERE "list" = NEW."list" AND "material" = NEW."material" AND "type" = 'like') WHERE "list" = NEW."list" AND "material" = NEW."material"; END IF; IF NEW."type" = 'dislike' THEN UPDATE "list_materials" SET "dislikes" = (SELECT COUNT(*) FROM "list_material_ratings" WHERE "list" = NEW."list" AND "material" = NEW."material" AND "type" = 'dislike') WHERE "list" = NEW."list" AND "material" = NEW."material"; END IF; RETURN NULL; END; $add_rating$ LANGUAGE plpgsql} ];
+  [ q{CREATE FUNCTION add_rating() RETURNS trigger AS $add_rating$ BEGIN IF NEW."type" = 'like' THEN UPDATE "list_materials" SET "likes" = (SELECT COUNT(*) FROM "list_material_ratings" WHERE "list" = NEW."list" AND "material" = NEW."material" AND "type" = 'like') WHERE "list" = NEW."list" AND "material" = NEW."material"; END IF; IF NEW."type" = 'dislike' THEN UPDATE "list_materials" SET "dislikes" = (SELECT COUNT(*) FROM "list_material_ratings" WHERE "list" = NEW."list" AND "material" = NEW."material" AND "type" = 'dislike') WHERE "list" = NEW."list" AND "material" = NEW."material"; END IF; RETURN NULL; END; $add_rating$ LANGUAGE plpgsql} ];
 
 $dm = make_dm('Pg');
 is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],

--- a/t/10-split-sql-chunk.t
+++ b/t/10-split-sql-chunk.t
@@ -14,7 +14,7 @@ sub make_dm {
   }, 'DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator';
 }
 
-my $dm = make_dm('MySQL');
+my $dm = make_dm('mysql');
 
 is_deeply [ $dm->_split_sql_chunk( <<'END' ) ], [ 'BEGIN SELECT * FROM YADAH END' ];
 BEGIN
@@ -25,7 +25,7 @@ END
 
 is_deeply [ $dm->_split_sql_chunk( 'foo', ' ', 'bar' ) ], [qw(foo bar)];
 
-$dm = make_dm('MySQL', txn_prep => 1);  # default, bw-comp.
+$dm = make_dm('mysql', txn_prep => 1);  # default, bw-comp.
 
 is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],
 BEGIN;
@@ -41,7 +41,7 @@ END
     'SELECT * FROM YADAH',
   ];
 
-$dm = make_dm('MySQL', txn_prep => 0);
+$dm = make_dm('mysql', txn_prep => 0);
 
 is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],
 BEGIN;
@@ -59,7 +59,7 @@ END
     'Commit',
   ];
 
-$dm = make_dm('MySQL', txn_prep => 0);
+$dm = make_dm('mysql', txn_prep => 0);
 
 is_deeply [ $dm->_split_sql_chunk( <<'END' ) ],
 insert into door (color) VALUES ('#000');


### PR DESCRIPTION
### Summary

#### Implement a more robust SQL splitter upon SQL::SplitStatement

- finds statement endings even when they are not terminated by ";\n"
- handles `BEGIN stmt1; stmt2; END` blocks
- handles MySQL `DELIMITER`
- does not get confused by `#` or `--` in strings

#### Do not remove "false" transactions

Do not create DDLs with surrounding `BEGIN`/`COMMIT` just to remove anything that _seems_ to be a transaction later in the deployment phase (which currently reliably fails with PROCEDUREs, TRIGGERs and everything else that uses the `BEGIN` keyword).

This feature is off by default to keep backwards-compatibility.

### References

Fixes
#47 
#68 
#72 
... and probably a few more