### PR TITLE
Replace producer_args with sqlt_args

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -533,7 +533,7 @@ sub _sqldiff_from_yaml {
   my @stmts = SQL::Translator::Diff::schema_diff(
     $source_schema, $db,
     $dest_schema,   $db,
-    { producer_args => $sqltargs }
+    { sqlt_args => $sqltargs }
   );
 
   if (!$self->txn_prep && $self->txn_wrap) {


### PR DESCRIPTION
As of [`SQL::Translator` version
1.63](https://github.com/dbsrgits/sql-translator/blob/master/Changes), the `producer_args` option has been renamed to `sqlt_args`.  Code still using `producer_args` now generates this deprecation warning:

```
SQL::Translator::Diff::schema_diff(): producer_args is deprecated -- it does
not go straight to the producer, it goes to the internal sqlt object.
Please use sqlt_args, which reflects how it's used at
..../DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm line 533
```

This commit updates the code to use the new option name, thus removing the deprecation warning, and hence resolving the issue mentioned in #77.

This PR is submitted in the hope that it is useful. If you wish for any changes, please don't hesitate to contact me and I'll be more than happy to update and resubmit as necessary.