### PR TITLE
Pass direction to SQL::Translator::Diff

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -533,7 +533,7 @@ sub _sqldiff_from_yaml {
   my @stmts = SQL::Translator::Diff::schema_diff(
     $source_schema, $db,
     $dest_schema,   $db,
-    { sqlt_args => $sqltargs }
+    { sqlt_args => { direction => $direction, %$sqltargs } },
   );
 
   if (!$self->txn_prep && $self->txn_wrap) {


### PR DESCRIPTION
### Why direction of migration is required

Imagine this steps:

V1 | V2 | V3
--- | --- | ---
X | Y:RX | X

Where `X` is column name, `Y:RX` is column with `Y` name and `reanmed_from` property set to `X` name.

What happens when we generate migration scripts

Migration | Diff result `[src, tar]` | Description
--- | --- | ---
v1 -> v2 | X, Y:RX | This works well. The `X` was renamed to `Y`.
v2 -> v3 | Y:RX, X | This is also expected. The `Y` was dropped and `X` was created.
v2 -> v1 | Y:RX, X | For downgrade script it is not expected that `Y` will be dropped and `X` will be created from scratch. During upgrade migration `v1->v2` it was renamed and now during downgrade `v2->v1` we expect it should be renamed back. But instead the drop happens because it works as designed for `upgrade` direction. But this scenario it is `downgrade`. Unfortunately We can not detect this automatically: the order of `[src, dst]` is the same and the set of `extra` properties are the same.

### Proposition
From the above to get the expected result during `downgrades` we need to pass the flag that the `downgrade` migration should be generated.



