### PR TITLE
Check UTF

### DIFF
--- a/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
+++ b/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
@@ -20,6 +20,7 @@ require DBIx::Class::Storage;   # loaded for type constraint
 use DBIx::Class::DeploymentHandler::Types;
 
 use Path::Class qw(file dir);
+use utf8;
 
 with 'DBIx::Class::DeploymentHandler::HandlesDeploy';
 
@@ -803,6 +804,7 @@ sub prepare_protoschema {
 
   open my $file, q(>), $filename;
   binmode $file;
+  utf8::encode($yml);
   print {$file} $yml;
   close $file;
 }

--- a/t/deploy_methods/sql_translator.t
+++ b/t/deploy_methods/sql_translator.t
@@ -200,7 +200,12 @@ VERSION3: {
    ok( $dm, 'DBIC::DH::SQL::Translator w/3.0 instantiates correctly');
 
    my $version = $s->schema_version();
-   $dm->prepare_deploy;
+   {
+      my @warns;
+      local $SIG{__WARN__} = sub { push @warns, shift };
+      $dm->prepare_deploy;
+      ok scalar @warns == 0, "UTF handled correctly. No 'Wide character in print' warning.";
+   }
    ok(
       -f file($sql_dir, qw(SQLite deploy 3.0 001-auto.sql )),
       '2.0 schema gets generated properly'

--- a/t/lib/DBICVersion_v3.pm
+++ b/t/lib/DBICVersion_v3.pm
@@ -1,5 +1,6 @@
 package DBICVersion::Foo;
 
+use utf8;
 use base 'DBIx::Class::Core';
 use strict;
 use warnings;
@@ -28,6 +29,34 @@ __PACKAGE__->add_columns(
 );
 
 __PACKAGE__->set_primary_key('foo');
+
+
+sub sqlt_deploy_hook {
+  my( $self, $sqlt_table ) =  @_;
+
+  $sqlt_table->schema->add_procedure(
+    name => 'test_utf',
+    parameters => [ name => '_string', type => 'text' ],
+    extra => {
+      returns => { type => 'VOID' },
+      definitions => [
+        { language => 'sql' },
+        { quote    => '$$', body => 'SELECT "перевірка ЮТФ/check UTF"' },
+      ]
+    }
+  );
+
+  $sqlt_table->schema->add_trigger(
+    name =>  'test_utf',
+    perform_action_when =>  'before',
+    database_events     =>  'update',
+    on_table            =>  $sqlt_table->name,
+    scope               =>  'row',
+    action              =>  q!EXECUTE PROCEDURE test_utf("перевірка ЮТФ/check UTF")!
+  );
+
+}
+
 
 package DBICVersion::Schema;
 use base 'DBIx::Class::Schema';


### PR DESCRIPTION
Fixes: https://github.com/frioux/DBIx-Class-DeploymentHandler/issues/65

I implemented the similar tests for [SQL::Translator](https://github.com/dbsrgits/sql-translator/pull/189), `DBIx::Class::DeploymentHandler` and [DBIx::Class::Migration](https://github.com/jjn1056/DBIx-Class-Migration/pull/154)

`SQL::Translator` test work well (because writing to a file is not involved).

`DBIx::Class::DeploymentHandler` does not work well. When `$yml` comes at `prepare_protoschema` on `my $yml = $sqlt->translate(data => $self->schema);` line it looks like:
```perl
DBG>

/home/kes/work/projects/github-forks/DBIx-Class-DeploymentHandler/lib/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
   x798:        carp "Overwriting existing DDL-YML file - $filename";
   x799:        unlink $filename;
    800:     } else {
   x801:        die "Cannot overwrite '$filename', either enable force_overwrite or delete it"
    802:     }
    803:   }
    804:
   x805:   open my $file, q(>), $filename;
   x806:   binmode $file;
   x807:   DB::x;
    808:   # utf8::encode($yml);
  >>809:   print {$file} $yml;
   x810:   close $file;
    811: }
    812:
    813: __PACKAGE__->meta->make_immutable;
    814:
    815: 1;
    816:
    817: # vim: ts=2 sw=2 expandtab
    818:
    819: __END__


DBG>peek $yml
SV = PV(0x600a9c398240) at 0x600a9c32a2a8
  REFCNT = 1
  FLAGS = (POK,IsCOW,pPOK,UTF8)
  PV = 0x600a9c3d5720 "---\nschema:\n  procedures:\n    test_utf:\n      extra:\n        definitions:\n          - language: sql\n          - body: SELECT \"\xD0\xBF\xD0\xB5\xD1\x80\xD0\xB5\xD0\xB2\xD1\x96\xD1\x80\xD0\xBA\xD0\xB0 \xD0\xAE\xD0\xA2\xD0\xA4/check UTF\"\n            quote: $$\n        returns:\n          type: VOID\n      name: test_utf\n      order: 1\n      owner: ''\n      parameters:\n        - name\n        - _string\n        - type\n        - text\n      sql: ''\n  tables:\n    Foo:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - foo\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n      fields:\n        bar:\n          data_type: VARCHAR\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: bar\n          order: 2\n          size:\n            - 10\n        baz:\n          data_type: VARCHAR\n          default_value: ~\n          is_nullable: 1\n          is_primary_key: 0\n          is_unique: 0\n          name: baz\n          order: 3\n          size:\n            - 10\n        biff:\n          data_type: VARCHAR\n          default_value: ~\n          is_nullable: 1\n          is_primary_key: 0\n          is_unique: 0\n          name: biff\n          order: 4\n          size:\n            - 10\n        foo:\n          data_type: INTEGER\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: foo\n          order: 1\n          size:\n            - 0\n      indices: []\n      name: Foo\n      options: []\n      order: 1\n  triggers:\n    test_utf:\n      action: EXECUTE PROCEDURE test_utf(\"\xD0\xBF\xD0\xB5\xD1\x80\xD0\xB5\xD0\xB2\xD1\x96\xD1\x80\xD0\xBA\xD0\xB0 \xD0\xAE\xD0\xA2\xD0\xA4/check UTF\")\n      database_events:\n        - update\n      fields: ~\n      name: test_utf\n      on_table: Foo\n      order: 1\n      perform_action_when: before\n      scope: row\n  views: {}\ntranslator:\n  add_drop_table: 0\n  filename: ~\n  no_comments: 0\n  parser_args:\n    sources:\n      - Foo\n  parser_type: SQL::Translator::Parser::DBIx::Class\n  producer_args: {}\n  producer_type: SQL::Translator::Producer::YAML\n  show_warnings: 0\n  trace: 0\n  version: 1.66\n"\0 [UTF8 "---\nschema:\n  procedures:\n    test_utf:\n      extra:\n        definitions:\n          - language: sql\n          - body: SELECT "\x{43f}\x{435}\x{440}\x{435}\x{432}\x{456}\x{440}\x{43a}\x{430} \x{42e}\x{422}\x{424}/check UTF"\n            quote: $$\n        returns:\n          type: VOID\n      name: test_utf\n      order: 1\n      owner: ''\n      parameters:\n        - name\n        - _string\n        - type\n        - text\n      sql: ''\n  tables:\n    Foo:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - foo\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n      fields:\n        bar:\n          data_type: VARCHAR\n          default_value: ~\n       
   is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: bar\n          order: 2\n          size:\n            - 10\n        baz:\n          data_type: VARCHAR\n          default_value: ~\n          is_nullable: 1\n          is_primary_key: 0\n          is_unique: 0\n          name: baz\n          order: 3\n          size:\n            - 10\n        biff:\n          data_type: VARCHAR\n          default_value: ~\n          is_nullable: 1\n          is_primary_key: 0\n          is_unique: 0\n          name: biff\n          order: 4\n          size:\n            - 10\n        foo:\n          data_type: INTEGER\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: foo\n          order: 1\n          size:\n            - 0\n      indices: []\n      name: Foo\n      options: []\n      order: 1\n  triggers:\n    test_utf:\n      action: EXECUTE PROCEDURE test_utf("\x{43f}\x{435}\x{440}\x{435}\x{432}\x{456}\x{440}\x{43a}\x{430} \x{42e}\x{422}\x{424}/check UTF")\n      database_events:\n        - update\n      fields: ~\n      name: test_utf\n      on_table: Foo\n      order: 1\n      perform_action_when: before\n      scope: row\n  views: {}\ntranslator:\n  add_drop_table: 0\n  filename: ~\n  no_comments: 0\n  parser_args:\n    sources:\n      - Foo\n  parser_type: SQL::Translator::Parser::DBIx::Class\n  producer_args: {}\n  producer_type: SQL::Translator::Producer::YAML\n  show_warnings: 0\n  trace: 0\n  version: 1.66\n"]
  CUR = 2228
  LEN = 2230
  COW_REFCNT = 1


DBG>peek $file
SV = IV(0x600a9c3d1d08) at 0x600a9c3d1d18
  REFCNT = 1
  FLAGS = (ROK)
  RV = 0x600a98b71a28
  SV = PVGV(0x600a9c3ca870) at 0x600a98b71a28
    REFCNT = 2
    FLAGS = ()
    NAME = "$_[...]"
    NAMELEN = 7
    GvSTASH = 0x600a97cfd9e0	"DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator"
    FLAGS = 0x0
    GP = 0x600a9c3ca6d0
      SV = 0x0
      REFCNT = 1
      IO = 0x600a9c392920
      FORM = 0x0  
      AV = 0x0
      HV = 0x0
      CV = 0x0
      CVGEN = 0x0
      GPFLAGS = 0x0 ()
      LINE = 146
      FILE = "(eval 753)[/home/kes/perl5/perlbrew/perls/perl-5.41.2/lib/5.41.2/Fatal.pm:1712]"
      EGV = 0x600a98b71a28	"$_[...]"

```
And the bug is reproducible for `DBIx::Class::Migration` test. When `$yml` comes at `prepare_protoschema` on `my $yml = $sqlt->translate(data => $self->schema);` line it looks like:
```
/home/kes/work/projects/github-forks/DBIx-Class-Migration/local/lib/perl5/DBIx/Class/DeploymentHandler/DeployMethod/SQL/Translator.pm
   x800:        unlink $filename;
    801:     } else {
   x802:        die "Cannot overwrite '$filename', either enable force_overwrite or delete it"
    803:     }
    804:   }
    805:
   x806:   open my $file, q(>), $filename;
   x807:   binmode $file;
   x808:   DB::x;
    809:   # utf8::encode($yml);
  >>810:   print {$file} $yml;
   x811:   close $file;
    812: }
    813:
    814: __PACKAGE__->meta->make_immutable;
    815:
    816: 1;
    817:
    818: # vim: ts=2 sw=2 expandtab
    819:
    820: __END__


DBG>peek $yml
SV = PV(0x5ddba19f56a0) at 0x5ddba0ceb260
  REFCNT = 1
  FLAGS = (POK,IsCOW,pPOK,UTF8)
  PV = 0x5ddba2151380 "---\nschema:\n  procedures:\n    test_utf:\n      extra:\n        definitions:\n          - language: sql\n          - body: SELECT \"\xD0\xBF\xD0\xB5\xD1\x80\xD0\xB5\xD0\xB2\xD1\x96\xD1\x80\xD0\xBA\xD0\xB0 \xD0\xAE\xD0\xA2\xD0\xA4/check UTF\"\n            quote: $$\n        returns:\n          type: VOID\n      name: test_utf\n      order: 1\n      owner: ''\n      parameters:\n        - name\n        - _string\n        - type\n        - text\n      sql: ''\n  tables:\n    artist:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - artist_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - country_fk\n          match_type: ''\n          name: artist_fk_country_fk\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - country_id\n          reference_table: country\n          type: FOREIGN KEY\n      fields:\n        artist_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: artist_id\n          order: 1\n          size:\n            - 0\n        country_fk:\n          data_type: integer\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: country_fk\n          order: 2\n          size:\n            - 0\n        first_name:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: first_name\n          order: 3\n          size:\n            - 96\n        last_name:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: last_name\n          order: 4\n          size:\n            - 96\n      indices:\n        - fields:\n            - country_fk\n          name: artist_idx_country_fk\n          options: []\n          type: NORMAL\n      name: artist\n      options: []\n      order: 3\n    artist_cd:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - artist_fk\n            - cd_fk\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - artist_fk\n          match_type: ''\n          name: artist_cd_fk_artist_fk\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - artist_id\n          reference_table: artist\n          type: FOREIGN KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - cd_fk\n          match_type: ''\n          name: artist_cd_fk_cd_fk\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - cd_id\n          reference_table: cd\n          type: FOREIGN KEY\n      fields:\n        artist_fk:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: artist_fk\n          order: 1\n          size:\n            - 0\n        cd_fk:\n          data_type: integer\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: cd_fk\n          order: 2\n          size:\n            - 0\n      indices:\n        - fields:\n            - artist_fk\n          name: artist_cd_idx_artist_fk\n          options: []\n          type: NORMAL\n        - fields:\n            - cd_fk\n          name: artist_cd_idx_cd_fk\n          options: []\n          type: NORMAL\n      name: artist_cd\n      options: []\n      order: 5\n    cd:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - cd_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n      fields:\n        cd_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: cd_id\n          order: 1\n          size:\n            - 0\n        order:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 1\n          is_primary_key: 0\n          is_unique: 0\n          name: order\n          order: 3\n          size:\n            - 96\n        title:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: title\n          order: 2\n          size:\n            - 96\n      indices: []\n      name: cd\n      options: []\n      order: 1\n    country:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - country_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - code\n          match_type: ''\n          name: country_code\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: UNIQUE\n      fields:\n        code:\n          data_type: char\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 1\n          name: code\n          order: 2\n          size:\n            - 3\n        country_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: country_id\n          order: 1\n          size:\n            - 0\n      indices: []\n      name: country\n      options: []\n      order: 2\n    track:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - track_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - cd\n          match_type: ''\n          name: track_fk_cd\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - cd_id\n          reference_table: cd\n          type: FOREIGN KEY\n      fields:\n        cd:\n          data_type: integer\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: cd\n          order: 2\n          size:\n            - 0\n        title:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: title\n          order: 3\n          size:\n            - 96\n        track_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: track_id\n          order: 1\n          size:\n            - 0\n      indices:\n        - fields:\n            - cd\n          name: track_idx_cd\n          options: []\n          type: NORMAL\n      name: track\n      options: []\n      order: 4\n  triggers:\n    test_utf:\n      action: EXECUTE PROCEDURE test_utf(\"\xD0\xBF\xD0\xB5\xD1\x80\xD0\xB5\xD0\xB2\xD1\x96\xD1\x80\xD0\xBA\xD0\xB0 \xD0\xAE\xD0\xA2\xD0\xA4/check UTF\")\n      database_events:\n        - update\n      fields: ~\n      name: test_utf\n      on_table: track\n      order: 1\n      perform_action_when: before\n      scope: row\n  views: {}\ntranslator:\n  add_drop_table: 0\n  filename: ~\n  no_comments: 0\n  parser_args:\n    sources:\n      - Artist\n      - ArtistCd\n      - Cd\n      - Country\n      - Track\n  parser_type: SQL::Translator::Parser::DBIx::Class\n  producer_args: {}\n  producer_type: SQL::Translator::Producer::YAML\n  show_warnings: 0\n  trace: 0\n  version: 1.66\n"\0 [UTF8 "---\nschema:\n  procedures:\n    test_utf:\n      extra:\n        definitions:\n          - language: sql\n          - body: SELECT "\x{43f}\x{435}\x{440}\x{435}\x{432}\x{456}\x{440}\x{43a}\x{430} \x{42e}\x{422}\x{424}/check UTF"\n            quote: $$\n        returns:\n          type: VOID\n      name: test_utf\n      order: 1\n      owner: ''\n      parameters:\n        - name\n        - _string\n        - type\n        - text\n      sql: ''\n  tables:\n    artist:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - artist_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - country_fk\n          match_type: ''\n          name: artist_fk_country_fk\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - country_id\n          reference_table: country\n          type: FOREIGN KEY\n      fields:\n        artist_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: artist_id\n          order: 1\n          size:\n            - 0\n        country_fk:\n          data_type: integer\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: country_fk\n          order: 2\n          size:\n            - 0\n        first_name:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: first_name\n          order: 3\n          size:\n            - 96\n        last_name:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: last_name\n          order: 4\n          size:\n            - 96\n      indices:\n        - fields:\n            - country_fk\n          name: artist_idx_country_fk\n          options: []\n          type: NORMAL\n      name: artist\n      options: []\n      order: 3\n    artist_cd:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - artist_fk\n            - cd_fk\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - artist_fk\n          match_type: ''\n          name: artist_cd_fk_artist_fk\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - artist_id\n          reference_table: artist\n          type: FOREIGN KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - cd_fk\n          match_type: ''\n          name: artist_cd_fk_cd_fk\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - cd_id\n          reference_table: cd\n          type: FOREIGN KEY\n      fields:\n        artist_fk:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: artist_fk\n          order: 1\n          size:\n            - 0\n        cd_fk:\n          data_type: integer\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: cd_fk\n          order: 2\n          size:\n            - 0\n      indices:\n        - fields:\n            - artist_fk\n          name: artist_cd_idx_artist_fk\n          options: []\n          type: NORMAL\n        - fields:\n            - cd_fk\n          name: artist_cd_idx_cd_fk\n          options: []\n          type: NORMAL\n      name: artist_cd\n      options: []\n      order: 5\n    cd:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - cd_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n      fields:\n        cd_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: cd_id\n          order: 1\n          size:\n            - 0\n        order:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 1\n          is_primary_key: 0\n          is_unique: 0\n          name: order\n          order: 3\n          size:\n            - 96\n        title:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: title\n          order: 2\n          size:\n            - 96\n      indices: []\n      name: cd\n      options: []\n      order: 1\n    country:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - country_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - code\n          match_type: ''\n          name: country_code\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: UNIQUE\n      fields:\n        code:\n          data_type: char\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 1\n          name: code\n          order: 2\n          size:\n            - 3\n        country_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: country_id\n          order: 1\n          size:\n            - 0\n      indices: []\n      name: country\n      options: []\n      order: 2\n    track:\n      constraints:\n        - deferrable: 1\n          expression: ''\n          fields:\n            - track_id\n          match_type: ''\n          name: ''\n          on_delete: ''\n          on_update: ''\n          options: []\n          reference_fields: []\n          reference_table: ''\n          type: PRIMARY KEY\n        - deferrable: 1\n          expression: ''\n          fields:\n            - cd\n          match_type: ''\n          name: track_fk_cd\n          on_delete: CASCADE\n          on_update: CASCADE\n          options: []\n          reference_fields:\n            - cd_id\n          reference_table: cd\n          type: FOREIGN KEY\n      fields:\n        cd:\n          data_type: integer\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: cd\n          order: 2\n          size:\n            - 0\n        title:\n          data_type: varchar\n          default_value: ~\n          is_nullable: 0\n          is_primary_key: 0\n          is_unique: 0\n          name: title\n          order: 3\n          size:\n            - 96\n        track_id:\n          data_type: integer\n          default_value: ~\n          is_auto_increment: 1\n          is_nullable: 0\n          is_primary_key: 1\n          is_unique: 0\n          name: track_id\n          order: 1\n          size:\n            - 0\n      indices:\n        - fields:\n            - cd\n          name: track_idx_cd\n          options: []\n          type: NORMAL\n      name: track\n      options: []\n      order: 4\n  triggers:\n    test_utf:\n      action: EXECUTE PROCEDURE test_utf("\x{43f}\x{435}\x{440}\x{435}\x{432}\x{456}\x{440}\x{43a}\x{430} \x{42e}\x{422}\x{424}/check UTF")\n      database_events:\n        - update\n      fields: ~\n      name: test_utf\n      on_table: track\n      order: 1\n      perform_action_when: before\n      scope: row\n  views: {}\ntranslator:\n  add_drop_table: 0\n  filename: ~\n  no_comments: 0\n  parser_args:\n    sources:\n      - Artist\n      - ArtistCd\n      - Cd\n      - Country\n      - Track\n  parser_type: SQL::Translator::Parser::DBIx::Class\n  producer_args: {}\n  producer_type: SQL::Translator::Producer::YAML\n  show_warnings: 0\n  trace: 0\n  version: 1.66\n"]
  CUR = 8463
  LEN = 8465
  COW_REFCNT = 1

DBG>peek $file
SV = IV(0x5ddba1402430) at 0x5ddba1402440
  REFCNT = 1
  FLAGS = (ROK)
  RV = 0x5ddba08b0fd8
  SV = PVGV(0x5ddba08374d0) at 0x5ddba08b0fd8
    REFCNT = 2
    FLAGS = ()
    NAME = "$_[...]"
    NAMELEN = 7
    GvSTASH = 0x5ddb9d563830	"DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator"
    FLAGS = 0x0
    GP = 0x5ddba213c3b0
      SV = 0x0
      REFCNT = 1
      IO = 0x5ddba0d4ee80
      FORM = 0x0  
      AV = 0x0
      HV = 0x0
      CV = 0x0
      CVGEN = 0x0
      GPFLAGS = 0x0 ()
      LINE = 146
      FILE = "(eval 1172)[/home/kes/perl5/perlbrew/perls/perl-5.41.2/lib/5.41.2/Fatal.pm:1712]"
      EGV = 0x5ddba08b0fd8	"$_[...]"
```

From the above you can see that in both cases `$yml` is the same. When it is being written into the file:
```perl
  open my $file, q(>), $filename;
  binmode $file;
  # utf8::encode($yml);    << The test fails without this
  print {$file} $yml;
  close $file;
```

Feel free to ask additional info if something is unclear.